### PR TITLE
fix: changing type definitions and checks

### DIFF
--- a/plugins/node/opentelemetry-hapi-instrumentation/src/hapi.ts
+++ b/plugins/node/opentelemetry-hapi-instrumentation/src/hapi.ts
@@ -107,6 +107,9 @@ export class HapiInstrumentation extends BasePlugin<typeof Hapi> {
         );
       });
 
+      // Casting as any is necessary here due to multiple overloads on the Hapi.ext
+      // function, which requires supporting a variety of different parameters
+      // as extension inputs
       shimmer.wrap(newServer, 'ext', originalExtHandler => {
         return instrumentation._getServerExtPatch(
           instrumentation,
@@ -274,6 +277,9 @@ export class HapiInstrumentation extends BasePlugin<typeof Hapi> {
         );
       });
 
+      // Casting as any is necessary here due to multiple overloads on the Hapi.ext
+      // function, which requires supporting a variety of different parameters
+      // as extension inputs
       shimmer.wrap(server, 'ext', originalExtHandler => {
         return instrumentation._getServerExtPatch(
           instrumentation,

--- a/plugins/node/opentelemetry-hapi-instrumentation/src/types.ts
+++ b/plugins/node/opentelemetry-hapi-instrumentation/src/types.ts
@@ -48,6 +48,32 @@ export type PatchableExtMethod = Hapi.Lifecycle.Method & {
   [handlerPatched]?: boolean;
 };
 
+export type ServerExtInput =
+  | ((
+      this: Hapi.Server,
+      ...args: [
+        | Hapi.ServerExtEventsObject
+        | Hapi.ServerExtEventsObject[]
+        | Hapi.ServerExtEventsRequestObject
+        | Hapi.ServerExtEventsRequestObject[]
+      ]
+    ) => void)
+  | ((
+      this: Hapi.Server,
+      ...args: [
+        Hapi.ServerExtType,
+        Hapi.ServerExtPointFunction,
+        Hapi.ServerExtOptions | undefined
+      ]
+    ) => void)
+  | ((this: Hapi.Server, ...args: ServerExtDirectInput) => void);
+
+export type ServerExtDirectInput = [
+  Hapi.ServerRequestExtType,
+  Hapi.Lifecycle.Method,
+  (Hapi.ServerExtOptions | undefined)?
+];
+
 export enum AttributeNames {
   HAPI_TYPE = 'hapi.type',
   PLUGIN_NAME = 'hapi.plugin.name',

--- a/plugins/node/opentelemetry-hapi-instrumentation/src/types.ts
+++ b/plugins/node/opentelemetry-hapi-instrumentation/src/types.ts
@@ -48,26 +48,6 @@ export type PatchableExtMethod = Hapi.Lifecycle.Method & {
   [handlerPatched]?: boolean;
 };
 
-export type ServerExtInput =
-  | ((
-      this: Hapi.Server,
-      ...args: [
-        | Hapi.ServerExtEventsObject
-        | Hapi.ServerExtEventsObject[]
-        | Hapi.ServerExtEventsRequestObject
-        | Hapi.ServerExtEventsRequestObject[]
-      ]
-    ) => void)
-  | ((
-      this: Hapi.Server,
-      ...args: [
-        Hapi.ServerExtType,
-        Hapi.ServerExtPointFunction,
-        Hapi.ServerExtOptions | undefined
-      ]
-    ) => void)
-  | ((this: Hapi.Server, ...args: ServerExtDirectInput) => void);
-
 export type ServerExtDirectInput = [
   Hapi.ServerRequestExtType,
   Hapi.Lifecycle.Method,

--- a/plugins/node/opentelemetry-hapi-instrumentation/src/utils.ts
+++ b/plugins/node/opentelemetry-hapi-instrumentation/src/utils.ts
@@ -42,6 +42,13 @@ export const isLifecycleExtType = (
   );
 };
 
+export const isLifecycleExtEventObj = (
+  variableToCheck: unknown
+): variableToCheck is Hapi.ServerExtEventsRequestObject => {
+  const event = (variableToCheck as Hapi.ServerExtEventsRequestObject)?.type;
+  return event !== undefined && isLifecycleExtType(event);
+};
+
 export const isDirectExtInput = (
   variableToCheck: unknown
 ): variableToCheck is ServerExtDirectInput => {

--- a/plugins/node/opentelemetry-hapi-instrumentation/src/utils.ts
+++ b/plugins/node/opentelemetry-hapi-instrumentation/src/utils.ts
@@ -21,6 +21,8 @@ import {
   AttributeNames,
   HapiLayerType,
   HapiLifecycleMethodNames,
+  PatchableExtMethod,
+  ServerExtDirectInput,
 } from './types';
 
 export function getPluginName<T>(plugin: Hapi.Plugin<T>): string {
@@ -38,6 +40,23 @@ export const isLifecycleExtType = (
     typeof variableToCheck === 'string' &&
     HapiLifecycleMethodNames.includes(variableToCheck)
   );
+};
+
+export const isDirectExtInput = (
+  variableToCheck: unknown
+): variableToCheck is ServerExtDirectInput => {
+  return (
+    Array.isArray(variableToCheck) &&
+    variableToCheck.length <= 3 &&
+    isLifecycleExtType(variableToCheck[0]) &&
+    typeof variableToCheck[1] === 'function'
+  );
+};
+
+export const isPatchableExtMethod = (
+  variableToCheck: PatchableExtMethod | PatchableExtMethod[]
+): variableToCheck is PatchableExtMethod => {
+  return !Array.isArray(variableToCheck);
 };
 
 export const getRouteMetadata = (


### PR DESCRIPTION
Currently, this version of the code is fully functional and runs without errors. However, it requires the usage of // @ts-ignore comments (see below), and overall feels a bit more verbose than the previous version (currently up to date in my [main PR](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/171)).
Another issue is that it is necessary to wrap this handler method " as any as T", as seen in the second screenshot, on like 223. I am also not sure how to get around this for the sake of TypeScript compilation, but it should not technically need to be cast again.

Supported parameter types for the Server.ext method in Hapi:
![Screenshot 2020-08-10 at 8 19 33 PM](https://user-images.githubusercontent.com/60523681/89853689-dcfd4180-db46-11ea-8460-dda3447ba89f.png)

Error regarding "this" param into the original handler method (currently suppressed by the //@ts-ignore comments)
![Screenshot 2020-08-10 at 8 06 45 PM](https://user-images.githubusercontent.com/60523681/89853710-ee464e00-db46-11ea-8377-465f65d75216.png)